### PR TITLE
fix(bmz-player): make play adjustment keys configurable

### DIFF
--- a/crates/bmz-player/src/app/play_control.rs
+++ b/crates/bmz-player/src/app/play_control.rs
@@ -1,3 +1,4 @@
+use crate::config::profile_config::{InputActionConfig, ProfileInputConfig};
 use bmz_gameplay::input::backend::PhysicalControl;
 
 use super::input_runtime::ControlInputEvent;
@@ -82,7 +83,10 @@ pub(super) enum GreenNumberChange {
     Down,
 }
 
-pub(super) fn keyboard_lane_action(event: &ControlInputEvent) -> Option<PlayLaneAction> {
+pub(super) fn keyboard_lane_action(
+    event: &ControlInputEvent,
+    input: &ProfileInputConfig,
+) -> Option<PlayLaneAction> {
     if !event.pressed {
         return None;
     }
@@ -90,11 +94,21 @@ pub(super) fn keyboard_lane_action(event: &ControlInputEvent) -> Option<PlayLane
         return None;
     };
     let lane_cover_step = if event.repeat { LANE_COVER_REPEAT_STEP } else { LANE_COVER_STEP };
-    match control.as_str() {
-        "ArrowLeft" => Some(PlayLaneAction::Hispeed(HispeedChange::Down)),
-        "ArrowRight" => Some(PlayLaneAction::Hispeed(HispeedChange::Up)),
-        "ArrowUp" => Some(PlayLaneAction::LaneCoverDelta(lane_cover_step)),
-        "ArrowDown" => Some(PlayLaneAction::LaneCoverDelta(-lane_cover_step)),
+    let action = input.ui.bindings.iter().find_map(|entry| {
+        (entry.device == "keyboard" && entry.control == *control)
+            .then_some(entry.action)
+            .flatten()
+            .filter(|action| {
+                crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS.contains(action)
+            })
+    })?;
+    match action {
+        InputActionConfig::PlayHispeedDown => Some(PlayLaneAction::Hispeed(HispeedChange::Down)),
+        InputActionConfig::PlayHispeedUp => Some(PlayLaneAction::Hispeed(HispeedChange::Up)),
+        InputActionConfig::PlayLaneCoverUp => Some(PlayLaneAction::LaneCoverDelta(lane_cover_step)),
+        InputActionConfig::PlayLaneCoverDown => {
+            Some(PlayLaneAction::LaneCoverDelta(-lane_cover_step))
+        }
         _ => None,
     }
 }
@@ -136,18 +150,73 @@ mod tests {
 
     #[test]
     fn keyboard_arrows_map_to_shared_lane_actions() {
+        let input = crate::config::play_input::default_profile_input();
         assert_eq!(
-            keyboard_lane_action(&keyboard(KeyCode::ArrowLeft, false)),
+            keyboard_lane_action(&keyboard(KeyCode::ArrowLeft, false), &input),
             Some(PlayLaneAction::Hispeed(HispeedChange::Down))
         );
         assert_eq!(
-            keyboard_lane_action(&keyboard(KeyCode::ArrowUp, false)),
+            keyboard_lane_action(&keyboard(KeyCode::ArrowUp, false), &input),
             Some(PlayLaneAction::LaneCoverDelta(LANE_COVER_STEP))
         );
         assert_eq!(
-            keyboard_lane_action(&keyboard(KeyCode::ArrowDown, true)),
+            keyboard_lane_action(&keyboard(KeyCode::ArrowDown, true), &input),
             Some(PlayLaneAction::LaneCoverDelta(-LANE_COVER_REPEAT_STEP))
         );
+    }
+
+    #[test]
+    fn remapped_and_cleared_shortcuts_survive_profile_reload() {
+        use crate::config::key_config::{
+            KeyBindingSlot, KeyBindingTarget, apply_play_binding, clear_play_binding,
+        };
+        use bmz_core::lane::KeyMode;
+        let mut input = crate::config::play_input::default_profile_input();
+        for (action, old_key, new_key, control, expected) in [
+            (
+                InputActionConfig::PlayHispeedDown,
+                KeyCode::ArrowLeft,
+                KeyCode::KeyH,
+                "H",
+                PlayLaneAction::Hispeed(HispeedChange::Down),
+            ),
+            (
+                InputActionConfig::PlayHispeedUp,
+                KeyCode::ArrowRight,
+                KeyCode::KeyJ,
+                "J",
+                PlayLaneAction::Hispeed(HispeedChange::Up),
+            ),
+            (
+                InputActionConfig::PlayLaneCoverUp,
+                KeyCode::ArrowUp,
+                KeyCode::KeyK,
+                "K",
+                PlayLaneAction::LaneCoverDelta(LANE_COVER_REPEAT_STEP),
+            ),
+            (
+                InputActionConfig::PlayLaneCoverDown,
+                KeyCode::ArrowDown,
+                KeyCode::KeyL,
+                "L",
+                PlayLaneAction::LaneCoverDelta(-LANE_COVER_REPEAT_STEP),
+            ),
+        ] {
+            let target = KeyBindingTarget::Action { action, slot: KeyBindingSlot::KeyboardPrimary };
+            apply_play_binding(&mut input, KeyMode::K7, target, control).unwrap();
+            input = toml::from_str(&toml::to_string(&input).unwrap()).unwrap();
+            crate::config::play_input::normalize_profile_input(&mut input);
+            assert_eq!(keyboard_lane_action(&keyboard(old_key, false), &input), None);
+            assert_eq!(keyboard_lane_action(&keyboard(new_key, true), &input), Some(expected));
+            let mut release = keyboard(new_key, false);
+            release.pressed = false;
+            assert_eq!(keyboard_lane_action(&release, &input), None);
+            clear_play_binding(&mut input, KeyMode::K7, target).unwrap();
+            input = toml::from_str(&toml::to_string(&input).unwrap()).unwrap();
+            crate::config::play_input::normalize_profile_input(&mut input);
+            assert_eq!(keyboard_lane_action(&keyboard(new_key, false), &input), None);
+            assert_eq!(keyboard_lane_action(&keyboard(old_key, false), &input), None);
+        }
     }
 
     #[test]

--- a/crates/bmz-player/src/app/play_support/controls.rs
+++ b/crates/bmz-player/src/app/play_support/controls.rs
@@ -164,6 +164,7 @@ fn play_input_claims_control(input: &PlayOptionInput, control: &PhysicalControl)
             InputActionConfig::E4,
         ]
         .into_iter()
+        .chain(crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS.iter().copied())
         .any(|action| input.is_action(W_KEYBOARD_DEVICE_ID, control, action))
 }
 

--- a/crates/bmz-player/src/app/play_support/input.rs
+++ b/crates/bmz-player/src/app/play_support/input.rs
@@ -4,7 +4,10 @@ pub(in crate::app) fn hispeed_action(
     state: ElementState,
     repeat: bool,
 ) -> Option<HispeedChange> {
-    match keyboard_lane_action(&ControlInputEvent::keyboard_parts(physical_key, state, repeat)) {
+    match keyboard_lane_action(
+        &ControlInputEvent::keyboard_parts(physical_key, state, repeat),
+        &crate::config::play_input::default_profile_input(),
+    ) {
         Some(PlayLaneAction::Hispeed(change)) => Some(change),
         _ => None,
     }
@@ -162,7 +165,10 @@ pub(in crate::app) fn lane_cover_step(
     state: ElementState,
     repeat: bool,
 ) -> Option<f32> {
-    match keyboard_lane_action(&ControlInputEvent::keyboard_parts(physical_key, state, repeat)) {
+    match keyboard_lane_action(
+        &ControlInputEvent::keyboard_parts(physical_key, state, repeat),
+        &crate::config::play_input::default_profile_input(),
+    ) {
         Some(PlayLaneAction::LaneCoverDelta(delta)) => Some(delta),
         _ => None,
     }

--- a/crates/bmz-player/src/app/select_flow/keyboard.rs
+++ b/crates/bmz-player/src/app/select_flow/keyboard.rs
@@ -107,7 +107,8 @@ impl WinitApp {
         } else {
             None
         };
-        let fixed_play_lane_action = keyboard_lane_action(&control_event);
+        let fixed_play_lane_action =
+            keyboard_lane_action(&control_event, &self.boot.profile_config.input);
         if self.play.active_play.is_some() {
             self.route_active_play_keyboard(
                 event,

--- a/crates/bmz-player/src/app/tests/play/cases_01.rs
+++ b/crates/bmz-player/src/app/tests/play/cases_01.rs
@@ -292,6 +292,59 @@ fn autoplay_replay_speed_keys_defer_to_current_play_bindings() {
 }
 
 #[test]
+fn autoplay_replay_speed_keys_defer_to_remapped_play_shortcuts() {
+    for &action in crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS {
+        for slot in [KeyBindingSlot::KeyboardPrimary, KeyBindingSlot::KeyboardSecondary] {
+            for (control, key, rate) in [
+                ("1", KeyCode::Digit1, 25),
+                ("2", KeyCode::Digit2, 50),
+                ("3", KeyCode::Digit3, 200),
+                ("4", KeyCode::Digit4, 300),
+            ] {
+                let mut input = crate::config::play_input::default_profile_input();
+                let target = KeyBindingTarget::Action { action, slot };
+                apply_play_binding(&mut input, KeyMode::K7, target, control).unwrap();
+                let pressed = HashSet::from([(
+                    W_KEYBOARD_DEVICE_ID,
+                    PhysicalControl::KeyboardKey(control.to_string()),
+                )]);
+                let play_input = play_option_input_for(&input, KeyMode::K7);
+                assert!(!is_unassigned_autoplay_replay_playback_rate_key(
+                    PhysicalKey::Code(key),
+                    Some(&play_input),
+                ));
+                assert_eq!(
+                    autoplay_replay_playback_rate_from_pressed_inputs(&pressed, Some(&play_input)),
+                    100,
+                );
+                assert!(
+                    keyboard_lane_action(
+                        &ControlInputEvent::keyboard_parts(
+                            PhysicalKey::Code(key),
+                            ElementState::Pressed,
+                            false,
+                        ),
+                        &input,
+                    )
+                    .is_some()
+                );
+
+                clear_play_binding(&mut input, KeyMode::K7, target).unwrap();
+                let play_input = play_option_input_for(&input, KeyMode::K7);
+                assert!(is_unassigned_autoplay_replay_playback_rate_key(
+                    PhysicalKey::Code(key),
+                    Some(&play_input),
+                ));
+                assert_eq!(
+                    autoplay_replay_playback_rate_from_pressed_inputs(&pressed, Some(&play_input)),
+                    rate,
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn play_control_hold_state_keeps_legacy_and_default_e1_fallbacks() {
     let mut legacy_input = crate::config::play_input::default_profile_input();
     legacy_input.ui.bindings.retain(|entry| entry.action != Some(InputActionConfig::E1));

--- a/crates/bmz-player/src/config/key_config.rs
+++ b/crates/bmz-player/src/config/key_config.rs
@@ -141,6 +141,10 @@ pub const COMMON_ACTIONS: &[InputActionConfig] = &[
     InputActionConfig::E2,
     InputActionConfig::E3,
     InputActionConfig::E4,
+    InputActionConfig::PlayHispeedDown,
+    InputActionConfig::PlayHispeedUp,
+    InputActionConfig::PlayLaneCoverUp,
+    InputActionConfig::PlayLaneCoverDown,
     InputActionConfig::SelectOpenFolder,
     InputActionConfig::SelectReload,
     InputActionConfig::SelectAutoplayFolder,
@@ -228,7 +232,15 @@ pub fn binding_target_label(key_mode: KeyMode, target: KeyBindingTarget) -> Stri
 }
 
 pub fn common_key_binding_targets(slot: KeyBindingSlot) -> Vec<KeyBindingTarget> {
-    COMMON_ACTIONS.iter().copied().map(|action| KeyBindingTarget::Action { action, slot }).collect()
+    COMMON_ACTIONS
+        .iter()
+        .copied()
+        .filter(|action| {
+            !slot.is_controller()
+                || !crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS.contains(action)
+        })
+        .map(|action| KeyBindingTarget::Action { action, slot })
+        .collect()
 }
 
 pub fn key_mode_binding_targets(key_mode: KeyMode, slot: KeyBindingSlot) -> Vec<KeyBindingTarget> {
@@ -247,6 +259,10 @@ pub fn key_mode_binding_targets(key_mode: KeyMode, slot: KeyBindingSlot) -> Vec<
 
 pub fn action_label(action: InputActionConfig) -> &'static str {
     match action {
+        InputActionConfig::PlayHispeedDown => "HISPEED DOWN",
+        InputActionConfig::PlayHispeedUp => "HISPEED UP",
+        InputActionConfig::PlayLaneCoverUp => "LANE COVER UP",
+        InputActionConfig::PlayLaneCoverDown => "LANE COVER DOWN",
         InputActionConfig::E1 => "E1",
         InputActionConfig::E2 => "E2",
         InputActionConfig::E3 => "E3",

--- a/crates/bmz-player/src/config/profile_config/bindings.rs
+++ b/crates/bmz-player/src/config/profile_config/bindings.rs
@@ -1,6 +1,13 @@
 use super::*;
 
-pub const UI_INPUT_BINDING_VERSION: u32 = 3;
+pub const UI_INPUT_BINDING_VERSION: u32 = 4;
+
+pub const PLAY_KEYBOARD_SHORTCUT_ACTIONS: &[InputActionConfig] = &[
+    InputActionConfig::PlayHispeedDown,
+    InputActionConfig::PlayHispeedUp,
+    InputActionConfig::PlayLaneCoverUp,
+    InputActionConfig::PlayLaneCoverDown,
+];
 
 pub const CONFIGURABLE_SHORTCUT_MIGRATIONS: &[(u32, &[InputActionConfig])] = &[
     (
@@ -26,9 +33,14 @@ pub const CONFIGURABLE_SHORTCUT_MIGRATIONS: &[(u32, &[InputActionConfig])] = &[
             InputActionConfig::SelectSameFolder,
         ],
     ),
+    (4, PLAY_KEYBOARD_SHORTCUT_ACTIONS),
 ];
 
 pub const CONFIGURABLE_SHORTCUT_ACTIONS: &[InputActionConfig] = &[
+    InputActionConfig::PlayHispeedDown,
+    InputActionConfig::PlayHispeedUp,
+    InputActionConfig::PlayLaneCoverUp,
+    InputActionConfig::PlayLaneCoverDown,
     InputActionConfig::SelectOpenFolder,
     InputActionConfig::SelectReload,
     InputActionConfig::SelectAutoplayFolder,
@@ -68,6 +80,10 @@ fn default_play_lane_bindings() -> Vec<BindingConfigEntry> {
 
 pub fn default_keyboard_bindings() -> Vec<BindingConfigEntry> {
     vec![
+        action_binding("ArrowLeft", InputActionConfig::PlayHispeedDown),
+        action_binding("ArrowRight", InputActionConfig::PlayHispeedUp),
+        action_binding("ArrowUp", InputActionConfig::PlayLaneCoverUp),
+        action_binding("ArrowDown", InputActionConfig::PlayLaneCoverDown),
         scratch_binding("LShift", LaneConfig::Scratch, ScratchDirectionConfig::Up),
         scratch_binding("LControl", LaneConfig::Scratch, ScratchDirectionConfig::Down),
         binding("Z", LaneConfig::Key1),

--- a/crates/bmz-player/src/config/profile_config/input.rs
+++ b/crates/bmz-player/src/config/profile_config/input.rs
@@ -159,6 +159,10 @@ pub enum ScratchDirectionConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum InputActionConfig {
+    PlayHispeedDown,
+    PlayHispeedUp,
+    PlayLaneCoverUp,
+    PlayLaneCoverDown,
     E1,
     /// Deprecated compatibility value. Runtime selection uses play-lane bindings.
     #[serde(rename = "Enter")]

--- a/crates/bmz-player/src/config/profile_config/tests.rs
+++ b/crates/bmz-player/src/config/profile_config/tests.rs
@@ -742,6 +742,29 @@ fn default_gamepad_ui_bindings_use_thumb_buttons_without_dpad_enter_back() {
 }
 
 #[test]
+fn v3_profile_migrates_play_shortcuts_once() {
+    let mut input = crate::config::play_input::default_profile_input();
+    input.ui.version = 3;
+    input.ui.bindings.retain(|entry| {
+        !entry.action.is_some_and(|action| PLAY_KEYBOARD_SHORTCUT_ACTIONS.contains(&action))
+    });
+    crate::config::play_input::normalize_profile_input(&mut input);
+    for &action in PLAY_KEYBOARD_SHORTCUT_ACTIONS {
+        assert_eq!(
+            input.ui.bindings.iter().filter(|entry| entry.action == Some(action)).count(),
+            1
+        );
+    }
+    input.ui.bindings.retain(|entry| {
+        !entry.action.is_some_and(|action| PLAY_KEYBOARD_SHORTCUT_ACTIONS.contains(&action))
+    });
+    crate::config::play_input::normalize_profile_input(&mut input);
+    assert!(!input.ui.bindings.iter().any(|entry| {
+        entry.action.is_some_and(|action| PLAY_KEYBOARD_SHORTCUT_ACTIONS.contains(&action))
+    }));
+}
+
+#[test]
 fn input_normalization_migrates_shortcuts_once_and_preserves_later_clears() {
     let mut input = crate::config::play_input::default_profile_input();
     input.ui.version = 0;

--- a/crates/bmz-player/src/screens/settings_model.rs
+++ b/crates/bmz-player/src/screens/settings_model.rs
@@ -650,7 +650,19 @@ mod tests {
     #[test]
     fn settings_keys_common_lists_configurable_actions() {
         let items = load_settings_items(CONFIG_KEYS_COMMON_PATH);
-        assert_eq!(items.len(), COMMON_ACTIONS.len() * KEY_BINDING_SLOTS.len() + 1);
+        assert_eq!(
+            items.len(),
+            COMMON_ACTIONS.len() * KEY_BINDING_SLOTS.len()
+                - crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS.len()
+                + 1
+        );
+        for &action in crate::config::profile_config::PLAY_KEYBOARD_SHORTCUT_ACTIONS {
+            for &slot in KEY_BINDING_SLOTS {
+                assert_eq!(items.iter().any(|item| matches!(item,
+                    SelectItem::KeyBinding(row) if row.target == KeyBindingTarget::Action { action, slot }
+                )), !slot.is_controller());
+            }
+        }
         assert!(matches!(items.first(), Some(SelectItem::SettingsBack)));
         assert!(matches!(
             &items[1],


### PR DESCRIPTION
Allow players to rebind or clear hispeed and lane cover shortcuts so arrow keys can be used for gameplay without also changing play settings.

- Add HISPEED DOWN/UP and LANE COVER UP/DOWN to common key settings.
- Replace hardcoded arrow shortcuts with saved profile bindings.
- Migrate existing profiles once, preserving subsequent remaps and clears.